### PR TITLE
fix: spawn Unknown system error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,8 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
+        # macos-13 is an intel runner, macos-14(macos-latest) is apple silicon
+        os: [macos-latest, windows-latest, macos-13]
 
     steps:
       - name: Check out Git repository
@@ -22,9 +23,35 @@ jobs:
         with:
           node-version: 20
 
-      - name: Build/release Electron app
+      - name: Build/release Electron app - Windows
         uses: samuelmeuli/action-electron-builder@v1.6.0
+        if: matrix.os == 'windows-latest'
         with:
+          # GitHub token, automatically provided to the action
+          # (No need to define this secret in the repo settings)
+          github_token: ${{ secrets.TOKEN }}
+          # If the commit is tagged with a version (e.g. "v1.0.0"),
+          # release the app after building
+          release: ${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Build/release Electron app - MacOS Intel
+        uses: samuelmeuli/action-electron-builder@v1.6.0
+        if: matrix.os == 'macos-13'
+        with:
+          args: "--x64"
+          # GitHub token, automatically provided to the action
+          # (No need to define this secret in the repo settings)
+          github_token: ${{ secrets.TOKEN }}
+
+          # If the commit is tagged with a version (e.g. "v1.0.0"),
+          # release the app after building
+          release: ${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Build/release Electron app - MacOS Arm
+        uses: samuelmeuli/action-electron-builder@v1.6.0
+        if: matrix.os == 'macos-latest'
+        with:
+          args: "--arm64"
           # GitHub token, automatically provided to the action
           # (No need to define this secret in the repo settings)
           github_token: ${{ secrets.TOKEN }}

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -13,9 +13,6 @@ publish: ['github']
 mac:
   target:
     - target: dmg
-      arch:
-        - arm64
-        - x64
   artifactName: "${productName}_Mac_${version}_${arch}.${ext}"
 win:
   target: nsis


### PR DESCRIPTION
close: #5 #15

最近刚好遇到这个问题，mac intel 使用`ffmpeg-static`异常报错 ` spawn Unknown system error -86`

大概原因是 Github Actions 似乎最近将 macos-laster 从 x86 升级到 M1 芯片，因此后安装的 `ffmpeg-static`为arm64的二进制文件

类似问题: 
https://github.com/desktop/dugite/issues/576#issuecomment-2233191658

可以验证 
[Video-Subtitle-Master_Mac_1.0.14_x64](https://github.com/buxuku/video-subtitle-master/releases/download/v1.0.14/Video-Subtitle-Master_Mac_1.0.14_x64.dmg) 安装后 查看
```bash
ll /Applications/Video\ Subtitle\ Master.app/Contents/Resources/app.asar.unpacked/node_modules/ffmpeg-static
...
43M ... ffmpeg
...
```
[Video.Subtitle.Master-1.0.0.dmg](https://github.com/buxuku/video-subtitle-master/releases/download/v1.0.0/Video.Subtitle.Master-1.0.0.dmg) 安装后 查看
```bash
ll /Applications/Video\ Subtitle\ Master.app/Contents/Resources/app.asar.unpacked/node_modules/ffmpeg-static
...
75M   ... ffmpeg
...
```

[macos-laster只有arm64](https://github.com/actions/runner-images/issues/9741)

所以使用`macos-13`单独打包 intel的包

为了测试修改是否正确 fork项目 https://github.com/gxr404/video-subtitle-master-fork/releases

有这个错误的用户可以试试验证下下面的版本是否正常，我自己的 mac intel是正常了
[Video-Subtitle-Master_Mac_1.0.20_x64.dmg](https://github.com/gxr404/video-subtitle-master-fork/releases/download/untagged-cc40712461300f16e3ec/Video-Subtitle-Master_Mac_1.0.20_x64.dmg)